### PR TITLE
Fix 1px sliver bug in landing header

### DIFF
--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -28,10 +28,11 @@ a {
     }
     &-2 {
         background-color: #ffffff;
-        clip-path: polygon(0 0, 0 100%, 40% 100%, 40% 30%, 65% 10%, 90% 30%, 90% 80%, 0% 80%, 40% 100%, 100% 100%, 100% 0%);      
+        clip-path: polygon(0 0, 0 100%, 40% 100%, 40% 30%, 65% 10%, 90% 30%, 90% 80%, 0% 80%, 40% 100%, 101% 100%, 101% 0%);      
         display: flex;
         grid-area: col2;
         opacity: 0.8;
+        width: 1000px;
         &-half {
             background: $color_bg-violet;
             color: #ffffff;


### PR DESCRIPTION
Due to antialiasing, css clip path for house-shaped cut out was causing a 1px offset to the center column of the header. 